### PR TITLE
 Use Application.compile_env for platforms to prevent re-running without recompiling dependency when config changes

### DIFF
--- a/lib/live_view_native/platforms.ex
+++ b/lib/live_view_native/platforms.ex
@@ -2,7 +2,7 @@ defmodule LiveViewNative.Platforms do
   @default_platforms [LiveViewNative.Platforms.Web]
 
   @env_platforms :live_view_native
-                 |> Application.get_env(:platforms, [])
+                 |> Application.compile_env(:platforms, [])
                  |> Enum.concat(@default_platforms)
                  |> Enum.map(fn platform_mod ->
                    platform_config = Application.get_env(:live_view_native, platform_mod)


### PR DESCRIPTION
Otherwise, in a client of the package, updating the config silently
fails to take effect until the dependency is recompiled, since the
config value is read at compile-time.

With this, changing the config and trying to re-run will result in this
error:

```
ERROR! the application :live_view_native has a different value set for key :platforms during runtime compared to compile time. Since this application environment entry was marked as compile time, this difference can lead to different behaviour than expected:

  * Compile time value was not set
  * Runtime value was set to: [LiveViewNativeSwiftUi.Platform]

To fix this error, you might:

  * Make the runtime value match the compile time one

  * Recompile your project. If the misconfigured application is a dependency, you may need to run "mix deps.compile live_view_native --force"

  * Alternatively, you can disable this check. If you are using releases, you can set :validate_compile_env to false in your release configuration. If you are using Mix to start your system, you can pass the --no-validate-compile-env flag
```

until the dependency is recompiled so the new config change takes
effect.