### PR TITLE
Support slots in HTML elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 live_view_native-*.tar
 
+.DS_Store

--- a/lib/live_view_native/engine.ex
+++ b/lib/live_view_native/engine.ex
@@ -466,6 +466,7 @@ defmodule LiveViewNative.Engine do
   defp handle_token(
     {:tag_open, ":" <> _, _attrs, _} = token,
     %{tags: [{:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
+  # Opposite clause to `validate_slot!/3`, ensures the parent element is _not_ a component
   ) when not (first in ?A..?Z) and first != ?. do
     # Translate into namespaced element `parent:slot_name`
     token = put_elem(token, 1, parent_name <> elem(token, 1))
@@ -475,6 +476,7 @@ defmodule LiveViewNative.Engine do
   defp handle_token(
     {:tag_close, ":" <> _, _tag_close_meta} = token,
     %{tags: [_, {:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
+  # Opposite clause to `validate_slot!/3`, ensures the parent element is _not_ a component
   ) when not (first in ?A..?Z) and first != ?. do
     # Translate into namespaced element `parent:slot_name`
     token = put_elem(token, 1, parent_name <> elem(token, 1))

--- a/lib/live_view_native/engine.ex
+++ b/lib/live_view_native/engine.ex
@@ -461,6 +461,26 @@ defmodule LiveViewNative.Engine do
     end
   end
 
+  # Slot (for HTML element)
+
+  defp handle_token(
+    {:tag_open, ":" <> slot_name, _attrs, tag_meta} = token,
+    %{tags: [{:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
+  ) when not (first in ?A..?Z) and first != ?. do
+    # Translate into namespaced element `parent:slot_name`
+    token = put_elem(token, 1, parent_name <> elem(token, 1))
+    handle_token(token, state)
+  end
+
+  defp handle_token(
+    {:tag_close, ":" <> slot_name = tag_name, _tag_close_meta} = token,
+    %{tags: [{:tag_open, open_slot_name, _, _}, {:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
+  ) when not (first in ?A..?Z) and first != ?. do
+      # Translate into namespaced element `parent:slot_name`
+    token = put_elem(token, 1, parent_name <> elem(token, 1))
+    handle_token(token, state)
+  end
+
   # Slot
 
   defp handle_token({:tag_open, ":inner_block", _attrs, meta}, state) do

--- a/lib/live_view_native/engine.ex
+++ b/lib/live_view_native/engine.ex
@@ -476,7 +476,7 @@ defmodule LiveViewNative.Engine do
     {:tag_close, ":" <> slot_name = tag_name, _tag_close_meta} = token,
     %{tags: [{:tag_open, open_slot_name, _, _}, {:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
   ) when not (first in ?A..?Z) and first != ?. do
-      # Translate into namespaced element `parent:slot_name`
+    # Translate into namespaced element `parent:slot_name`
     token = put_elem(token, 1, parent_name <> elem(token, 1))
     handle_token(token, state)
   end

--- a/lib/live_view_native/engine.ex
+++ b/lib/live_view_native/engine.ex
@@ -464,7 +464,7 @@ defmodule LiveViewNative.Engine do
   # Slot (for HTML element)
 
   defp handle_token(
-    {:tag_open, ":" <> slot_name, _attrs, tag_meta} = token,
+    {:tag_open, ":" <> _, _attrs, _} = token,
     %{tags: [{:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
   ) when not (first in ?A..?Z) and first != ?. do
     # Translate into namespaced element `parent:slot_name`
@@ -473,8 +473,8 @@ defmodule LiveViewNative.Engine do
   end
 
   defp handle_token(
-    {:tag_close, ":" <> slot_name = tag_name, _tag_close_meta} = token,
-    %{tags: [{:tag_open, open_slot_name, _, _}, {:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
+    {:tag_close, ":" <> _, _tag_close_meta} = token,
+    %{tags: [_, {:tag_open, <<first, _::binary>> = parent_name, _, _} | _]} = state
   ) when not (first in ?A..?Z) and first != ?. do
     # Translate into namespaced element `parent:slot_name`
     token = put_elem(token, 1, parent_name <> elem(token, 1))


### PR DESCRIPTION
A simple translation is performed on slots that are not in a component.

Here's an example. The user writes the following template:

```html
<menu>
    <:label>
        <text>Choose Item</text>
    </:label>
    <:content>
        <%= for item <- 1..5 do %>
            <button>Option <%= item %></button>
        <% end %>
    </:content>
</menu>
```

It is automatically translated by the engine into:

```html
<menu>
    <menu:label>
        <text>Choose Item</text>
    </menu:label>
    <menu:content>
        <%= for item <- 1..5 do %>
            <button>Option <%= item %></button>
        <% end %>
    </menu:content>
</menu>
```

While it may be possible to just pass the slots through as elements with a leading colon, I am unsure whether the client's parser would be able to determine if the element is simply unnamespaced (e.x. `<label>`) or has a namespace but it's blank (e.x. `<:label>`).