### PR TITLE
Add native bindings

### DIFF
--- a/lib/live_view_native/bindings.ex
+++ b/lib/live_view_native/bindings.ex
@@ -1,0 +1,67 @@
+defmodule LiveViewNative.Bindings do
+  defmacro native_binding(name, type, default) do
+    quote bind_quoted: [name: name, type: type, default: default] do
+      case Module.get_attribute(__MODULE__, :_native_bindings) do
+        nil ->
+          @_native_bindings %{name => {type, default}}
+
+        existing ->
+          @_native_bindings Map.put(existing, name, {type, default})
+      end
+
+      def _native_bindings, do: @_native_bindings
+      defoverridable [{:_native_bindings, 0}]
+
+      unless Module.get_attribute(__MODULE__, :_defined_native_binding_functions, false) do
+        @_defined_native_binding_functions true
+
+        on_mount {__MODULE__, :_set_native_binding_defaults}
+
+        def on_mount(:_set_native_binding_defaults, _params, _session, socket) do
+          defaults =
+            Enum.map(_native_bindings(), fn {name, {_type, default}} -> {name, default} end)
+
+          {
+            :cont,
+            socket
+            |> assign_native_bindings(defaults)
+          }
+        end
+
+        def handle_event("_native_bindings", values, socket) do
+          assigns =
+            Enum.reduce(values, %{}, fn {name, json_value}, acc ->
+              name_as_atom = String.to_existing_atom(name)
+
+              case Map.get(_native_bindings(), name_as_atom) do
+                nil ->
+                  acc
+
+                {type, _default} ->
+                  impl_module = Module.concat(LiveViewNative.JSONCoercable, type)
+
+                  Map.put(
+                    acc,
+                    name_as_atom,
+                    impl_module.from_json(json_value)
+                  )
+              end
+            end)
+
+          {:noreply, assign(socket, assigns)}
+        end
+
+        def assign_native_bindings(socket, map) do
+          event_payload =
+            Map.new(map, fn {name, value} ->
+              {name, LiveViewNative.JSONCoercable.to_json(value)}
+            end)
+
+          socket
+          |> assign(map)
+          |> push_event("_native_bindings", event_payload)
+        end
+      end
+    end
+  end
+end

--- a/lib/live_view_native/json_coercable.ex
+++ b/lib/live_view_native/json_coercable.ex
@@ -1,0 +1,124 @@
+defprotocol LiveViewNative.JSONCoercable do
+  @type json_value ::
+          atom()
+          | boolean()
+          | nil
+          | String.t()
+          | integer()
+          | float()
+          | %{(atom() | String.t()) => json_value()}
+          | [json_value()]
+
+  @spec to_json(term()) :: json_value()
+  def to_json(value)
+
+  @spec from_json(json_value()) :: term()
+  def from_json(json_value)
+end
+
+alias LiveViewNative.JSONCoercable
+
+defimpl JSONCoercable, for: Any do
+  defmacro __deriving__(module, struct, fields) do
+    quote location: :keep do
+      defimpl JSONCoercable, for: unquote(module) do
+        def to_json(value) do
+          Enum.reduce(unquote(fields), %{}, fn {field, type}, acc ->
+            json_value =
+              value
+              |> Map.get(field)
+              |> JSONCoercable.to_json()
+
+            Map.put(acc, field, json_value)
+          end)
+        end
+
+        def from_json(json_value) when is_map(json_value) do
+          Enum.reduce(unquote(fields), unquote(Macro.escape(struct)), fn {field, type}, acc ->
+            value =
+              Map.get_lazy(json_value, field, fn -> Map.get(json_value, Atom.to_string(field)) end)
+              # need to concat to get the impl module ourselves, since protocol dispatch won't work with the json value type
+              |> Module.concat(JSONCoercable, type).from_json()
+
+            Map.put(acc, field, value)
+          end)
+        end
+
+        def from_json(json_value) do
+          raise ArgumentError,
+                "cannot coerce struct #{unquote(module)} from non-map value: #{inspect(json_value)}"
+        end
+      end
+    end
+  end
+
+  def to_json(value) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: value,
+      description: "JSONCoercable must be explicitly implemented"
+  end
+
+  def from_json(json_value) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      json_value: json_value,
+      description: "JSONCoercable must be explicitly implemented"
+  end
+end
+
+defimpl JSONCoercable, for: Atom do
+  def to_json(v) when v in [nil, false, true], do: v
+
+  def to_json(value), do: Atom.to_string(value)
+
+  def from_json(v) when v in [nil, false, true], do: v
+
+  def from_json(json_value) when is_binary(json_value), do: String.to_existing_atom(json_value)
+end
+
+# binaries dispatch to BitString, but implement for String, so you can specify `String` in a coercable type
+defimpl JSONCoercable, for: String do
+  def to_json(value), do: value
+  def from_json(json_value) when is_binary(json_value), do: json_value
+end
+
+# binaries dispatch to BitString, so implement it for that too, but limited to binaries
+defimpl JSONCoercable, for: BitString do
+  def to_json(value) when is_binary(value), do: value
+  def from_json(json_value) when is_binary(json_value), do: json_value
+end
+
+defimpl JSONCoercable, for: Integer do
+  def to_json(value), do: value
+  def from_json(json_value) when is_integer(json_value), do: json_value
+end
+
+defimpl JSONCoercable, for: Float do
+  def to_json(value), do: value
+  def from_json(json_value) when is_float(json_value), do: json_value
+  def from_json(json_value) when is_integer(json_value), do: json_value * 1.0
+end
+
+defimpl JSONCoercable, for: Map do
+  def to_json(value) do
+    Map.new(value, fn {k, v} -> {k, JSONCoercable.to_json(v)} end)
+  end
+
+  def from_json(json_value) when is_map(json_value) do
+    # pass through values directly, since we don't have any info about the value type
+    # this means that round-tripping a map through JSONCoercable may produce a map with different values
+    json_value
+  end
+end
+
+defimpl JSONCoercable, for: List do
+  def to_json(value) do
+    Enum.map(value, &JSONCoercable.to_json/1)
+  end
+
+  def from_json(json_value) when is_list(json_value) do
+    # pass through values directly, same as with Map
+    json_value
+  end
+end

--- a/lib/live_view_native/live_view.ex
+++ b/lib/live_view_native/live_view.ex
@@ -15,6 +15,7 @@ defmodule LiveViewNative.LiveView do
   defmacro __using__(_opts \\ []) do
     quote do
       use LiveViewNative.Extensions
+      import LiveViewNative.Bindings
 
       on_mount {LiveViewNative.LiveSession, :live_view_native}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule LiveViewNative.MixProject do
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      consolidate_protocols: Mix.env() != :test
     ]
   end
 

--- a/test/live_view_native/json_coercable_test.exs
+++ b/test/live_view_native/json_coercable_test.exs
@@ -1,0 +1,58 @@
+defmodule LiveViewNative.JSONCoercableTest do
+  use ExUnit.Case
+  alias LiveViewNative.JSONCoercable
+  import JSONCoercable
+
+  defmodule Point do
+    @derive {JSONCoercable, [x: Integer, y: Integer]}
+    defstruct x: 0, y: 0
+  end
+
+  defmodule Nested do
+    @derive {JSONCoercable, [point: Point, string: String]}
+    defstruct point: %Point{x: 0, y: 0}, string: ""
+  end
+
+  defp coerce_to(type, json_value) do
+    Module.concat(JSONCoercable, type).from_json(json_value)
+  end
+
+  test "coerces primitive types to json" do
+    assert to_json(:hello) == "hello"
+    assert to_json(false) == false
+    assert to_json(nil) == nil
+    assert to_json("world") == "world"
+    assert to_json(123) == 123
+    assert to_json(42.0) == 42.0
+    assert to_json(%{foo: 123, bar: :baz}) == %{foo: 123, bar: "baz"}
+    assert to_json([:hello]) == ["hello"]
+  end
+
+  test "coerces primitive types from json" do
+    assert coerce_to(Atom, "hello") == :hello
+    assert coerce_to(Atom, false) == false
+    assert coerce_to(Atom, nil) == nil
+    assert coerce_to(String, "world") == "world"
+    assert coerce_to(Integer, 123) == 123
+    assert coerce_to(Float, 42.0) == 42.0
+    assert coerce_to(Map, %{"foo" => 123}) == %{"foo" => 123}
+    assert coerce_to(List, ["hello"]) == ["hello"]
+  end
+
+  test "coerces simple structs" do
+    assert to_json(%Point{x: 1, y: 2}) == %{x: 1, y: 2}
+    assert coerce_to(Point, %{"x" => 1, "y" => 2}) == %Point{x: 1, y: 2}
+  end
+
+  test "coerces nested types" do
+    assert to_json(%Nested{point: %Point{x: 3, y: 4}, string: "hello"}) == %{
+             point: %{x: 3, y: 4},
+             string: "hello"
+           }
+
+    assert coerce_to(Nested, %{"point" => %{"x" => 3, "y" => 4}, "string" => "hello"}) == %Nested{
+             point: %Point{x: 3, y: 4},
+             string: "hello"
+           }
+  end
+end


### PR DESCRIPTION
Closes liveviewnative/liveview-client-swiftui#244. I think it's reasonable to have the bindings helpers in this repo, since the implementation is platform agnostic, and you can imagine the same two-way client/server bindings being useful on Jetpack or other platforms.

Also adds a mechanism for converting to/from JSON-shaped (but not actually encoded) data, since that's what we get/provide with the LiveView socket API.

It can be implemented manually or derived on struct types like so:

```elixir
defmodule Point do
  @derive {JSONCoercable, [x: Float, y: Float]}
  defstruct [:x, :y]
end
```
which will coerce to/from `%{"x" => 1.0, "y" => 1.0}`.

And then the binding API can be used with any of the builtin or custom coercable types:

```elixir
defmodule BackendtestWeb.TestLive do
  use BackendtestWeb, :live_view
  use LiveViewNative.LiveView

  native_binding(:text, String, "")
  native_binding(:num, Integer, 123)
  native_binding(:point, Point, %Point{x: 1.0, y: 1.0})

  # ...
end
```